### PR TITLE
Adds 'material' sets, fixes resumptionToken when a "from" date is given in a ListRecords query

### DIFF
--- a/app/config/sets.yml
+++ b/app/config/sets.yml
@@ -9,4 +9,5 @@ parameters:
             - 'descriptiveMetadata/objectClassificationWrap/classificationWrap/classification[@type="objectcategorie"]/term[@pref="alternate"]'
             - 'descriptiveMetadata/objectClassificationWrap/classificationWrap/classification[@type="objectcategorie"]/term[@pref="preferred"]'
         subject: 'descriptiveMetadata/objectRelationWrap/subjectWrap/subjectSet/subject/subjectConcept/term'
-        material: 'descriptiveMetadata/eventWrap/eventSet/event[eventType/term="production"]/eventMaterialsTech/materialsTech/termMaterialsTech/term[@pref="preferred"]'
+        material: 'descriptiveMetadata/eventWrap/eventSet/event[eventType/term="production"]/eventMaterialsTech/materialsTech/termMaterialsTech[@type="material"]/term[@pref="preferred"]'
+        technique: 'descriptiveMetadata/eventWrap/eventSet/event[eventType/term="production"]/eventMaterialsTech/materialsTech/termMaterialsTech[@type="technique"]/term[@pref="preferred"]'

--- a/src/DataHub/OAIBundle/Repository/Repository.php
+++ b/src/DataHub/OAIBundle/Repository/Repository.php
@@ -140,7 +140,7 @@ class Repository implements InterfaceRepository
             $intervalCount = count($records);
         } else {
             $records = $this->recordRepository->findByBetweenFromUntil($from, $until, $limit, $offset);
-            $intervalCount = count($records);
+            $intervalCount = $records->count(true);
             $totalCount = $this->recordRepository->findByBetweenFromUntil($from, $until, null, null, true);
         }
 

--- a/src/DataHub/OAIBundle/Repository/Repository.php
+++ b/src/DataHub/OAIBundle/Repository/Repository.php
@@ -140,8 +140,8 @@ class Repository implements InterfaceRepository
             $intervalCount = count($records);
         } else {
             $records = $this->recordRepository->findByBetweenFromUntil($from, $until, $limit, $offset);
-            $intervalCount = $records->count(true);
-            $totalCount = count($this->recordRepository->findByBetweenFromUntil($from, $until, null, null, true));
+            $intervalCount = count($records);
+            $totalCount = $this->recordRepository->findByBetweenFromUntil($from, $until, null, null, true);
         }
 
         $token = null;
@@ -179,7 +179,6 @@ class Repository implements InterfaceRepository
         $params = $this->decodeResumptionToken($token);
         extract($params);
 
-        //TODO does this even work?
         $records = $this->listRecords($metadataPrefix, $from, $until, $set, $offset);
 
         $totalCount = $records->getCompleteListSize();
@@ -267,7 +266,7 @@ class Repository implements InterfaceRepository
      *
      * @param int $offset
      * @param DateTime $from
-     * @param DateTime $util
+     * @param DateTime $until
      * @param string $metadataPrefix
      * @param string $set
      *
@@ -276,7 +275,7 @@ class Repository implements InterfaceRepository
     private function encodeResumptionToken(
         $offset = 0,
         DateTime $from = null,
-        DateTime $util = null,
+        DateTime $until = null,
         $metadataPrefix = null,
         $set = null
     ) {
@@ -291,8 +290,8 @@ class Repository implements InterfaceRepository
             $params['from'] = $from->getTimestamp();
         }
 
-        if ($util) {
-            $params['until'] = $util->getTimestamp();
+        if ($until) {
+            $params['until'] = $until->getTimestamp();
         }
 
         return base64_encode(json_encode($params));


### PR DESCRIPTION
## Description

Adds 'technique' sets to the Datahub, fixes the resumptionToken not correctly working when a "from" date is given in a ListRecords query.

## Motivation and context

When a "from" date is provided with a ListRecords query, the resumptionToken was not properly formed and an incorrect size of the complete list provided. This pull request fixes that.

## How has this been tested?

By performing a search query on a live Datahub instance, which did not return the correct list size nor a resumptionToken when a "from" date was provided. It did provide the proper list size and a resumptionToken after the change.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
